### PR TITLE
feat(map_loader): change onServiceGetSelectedPointCloudMap into const function

### DIFF
--- a/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp
+++ b/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.cpp
@@ -62,7 +62,7 @@ SelectedMapLoaderModule::SelectedMapLoaderModule(
 
 bool SelectedMapLoaderModule::onServiceGetSelectedPointCloudMap(
   GetSelectedPointCloudMap::Request::SharedPtr req,
-  GetSelectedPointCloudMap::Response::SharedPtr res)
+  GetSelectedPointCloudMap::Response::SharedPtr res) const
 {
   const auto request_ids = req->cell_ids;
   for (const auto & request_id : request_ids) {

--- a/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.hpp
+++ b/map/map_loader/src/pointcloud_map_loader/selected_map_loader_module.hpp
@@ -51,7 +51,7 @@ private:
 
   bool onServiceGetSelectedPointCloudMap(
     GetSelectedPointCloudMap::Request::SharedPtr req,
-    GetSelectedPointCloudMap::Response::SharedPtr res);
+    GetSelectedPointCloudMap::Response::SharedPtr res) const;
   autoware_map_msgs::msg::PointCloudMapCellWithID loadPointCloudMapCellWithID(
     const std::string & path, const std::string & map_id) const;
 };


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Change `onServiceGetSelectedPointCloudMap` into const function.
See https://github.com/autowarefoundation/autoware.universe/pull/3286#discussion_r1161466278 for detail.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

- https://github.com/autowarefoundation/autoware.universe/pull/3286
   - add selected map loading support
- https://github.com/autowarefoundation/autoware_launch/pull/285
   - modify config for pointcloud_map_loader

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

